### PR TITLE
feat(data_connector): fetch publications by author name

### DIFF
--- a/dblp/publication.json
+++ b/dblp/publication.json
@@ -4,8 +4,14 @@
         "url": "https://dblp.org/search/publ/api",
         "method": "GET",
         "params": {
-            "q": true,
-            "h": false
+            "q": false,
+            "h": false,
+            "author": {
+                "template": "author:{{first_name}}_{{last_name}}:",
+                "required": false,
+                "removeIfEmpty": true,
+                "toKey": "q"
+            }
         }
     },
     "response": {


### PR DESCRIPTION
allows a user to fetch publications by specific first_name and last_name instead of a generalized q parameter

closes sfu-db/dataprep#50