### PR TITLE
update(tweest.json) : make the query pararmeter optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .mypy_cache
+.idea

--- a/twitter/tweets.json
+++ b/twitter/tweets.json
@@ -9,7 +9,7 @@
             "tokenServerUrl": "https://api.twitter.com/oauth2/token"
         },
         "params": {
-            "q": true,
+            "q": false,
             "count": false,
             "max_id": false
         },


### PR DESCRIPTION
Some projects just need random number for tweets (for example get 1000 tweets). Hence making the query parameter optional would be helpful here. 