### PR TITLE
fix(pagination): fix missing attribute in Twitter schema

### DIFF
--- a/twitter/tests/tests.py
+++ b/twitter/tests/tests.py
@@ -1,0 +1,5 @@
+from dataprep.data_connector import Connector
+
+
+def test_sanity():
+    pass

--- a/twitter/tweets.json
+++ b/twitter/tweets.json
@@ -44,6 +44,11 @@
             "hashtags":{
                 "target": "$.entities.hashtags",
                 "type": "string"
+            },
+            "id": 
+            {
+                "target": "$.id",
+                "type": "int"
             }
         },
         "orient": "records"


### PR DESCRIPTION
This PR fixes the bug that user is not able to take more than 100 tweets using data connector. It's due to the missing cursor attribute in config file of Twitter API.