### PR TITLE
feat(data_connector): adding support to Finnhub Fintech API

### DIFF
--- a/finnhub/_meta.json
+++ b/finnhub/_meta.json
@@ -1,0 +1,15 @@
+{
+    "tables": [
+        "general_news",
+        "company_news",
+        "filings",
+        "ipo_calender",
+        "recommendations",
+        "earnings",
+        "earnings_calender",
+        "patterns",
+        "covid19",
+        "countries",
+        "economic_calender"
+    ]
+}

--- a/finnhub/company_news.json
+++ b/finnhub/company_news.json
@@ -1,0 +1,64 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/company-news",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "symbol": true,
+"from_": true,
+"from": {
+    "required": false,
+    "removeIfEmpty": true,
+    "template": "{{from_}}"
+},
+"to": true
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$[*]",
+        "schema": {
+            "category": {
+                "target": "$.category",
+                "type": "string"
+            },
+            "datetime": {
+                "target": "$.datetime",
+                "type": "int"
+            },
+            "headline": {
+                "target": "$.headline",
+                "type": "string"
+            },
+            "id": {
+                "target": "$.id",
+                "type": "int"
+            },
+            "image": {
+                "target": "$.image",
+                "type": "string"
+            },
+            "related": {
+                "target": "$.related",
+                "type": "string"
+            },
+            "source": {
+                "target": "$.source",
+                "type": "string"
+            },
+            "summary": {
+                "target": "$.summary",
+                "type": "string"
+            },
+            "url": {
+                "target": "$.url",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/countries.json
+++ b/finnhub/countries.json
@@ -1,0 +1,44 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/country",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$[*]",
+        "schema": {
+            "country": {
+                "target": "$.country",
+                "type": "string"
+            },
+            "code2": {
+                "target": "$.code2",
+                "type": "string"
+            },
+            "code3": {
+                "target": "$.code3",
+                "type": "string"
+            },
+            "codeNo": {
+                "target": "$.codeNo",
+                "type": "string"
+            },
+            "currency": {
+                "target": "$.currency",
+                "type": "string"
+            },
+            "currencyCode": {
+                "target": "$.currencyCode",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/covid19.json
+++ b/finnhub/covid19.json
@@ -1,0 +1,36 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/covid19/us",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$[*]",
+        "schema": {
+            "state": {
+                "target": "$.state",
+                "type": "string"
+            },
+            "case": {
+                "target": "$.case",
+                "type": "int"
+            },
+            "death": {
+                "target": "$.death",
+                "type": "int"
+            },
+            "updated": {
+                "target": "$.updated",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/earnings.json
+++ b/finnhub/earnings.json
@@ -1,0 +1,38 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/stock/earnings",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "symbol": true,
+            "limit": false
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$[*]",
+        "schema": {
+            "actual": {
+                "target": "$.actual",
+                "type": "float"
+            },
+            "estimate": {
+                "target": "$.estimate",
+                "type": "float"
+            },
+            "period": {
+                "target": "$.period",
+                "type": "string"
+            },
+            "symbol": {
+                "target": "$.symbol",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/earnings_calender.json
+++ b/finnhub/earnings_calender.json
@@ -1,0 +1,65 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/calendar/earnings",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "symbol": false,
+            "from_": false,
+            "from": {
+                "required": false,
+                "removeIfEmpty": true,
+                "template": "{{from_}}"
+            },
+            "to": false,
+            "international": false
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$.earningsCalendar[*]",
+        "schema": {
+            "date": {
+                "target": "$.date",
+                "type": "string"
+            },
+            "epsActual": {
+                "target": "$.epsActual",
+                "type": "float"
+            },
+            "epsEstimate": {
+                "target": "$.epsEstimate",
+                "type": "float"
+            },
+            "hour": {
+                "target": "$.hour",
+                "type": "string"
+            },
+            "quarter": {
+                "target": "$.quarter",
+                "type": "int"
+            },
+            "revenueActual": {
+                "target": "$.revenueActual",
+                "type": "float"
+            },
+            "revenueEstimate": {
+                "target": "$.revenueEstimate",
+                "type": "float"
+            },
+            "symbol": {
+                "target": "$.symbol",
+                "type": "string"
+            },
+            "year": {
+                "target": "$.year",
+                "type": "int"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/economic_calender.json
+++ b/finnhub/economic_calender.json
@@ -1,0 +1,52 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/calendar/economic",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$.economicCalendar[*]",
+        "schema": {
+            "actual": {
+                "target": "$.actual",
+                "type": "float"
+            },
+            "country": {
+                "target": "$.country",
+                "type": "string"
+            },
+            "estimate": {
+                "target": "$.estimate",
+                "type": "float"
+            },
+            "event": {
+                "target": "$.event",
+                "type": "string"
+            },
+            "impact": {
+                "target": "$.impact",
+                "type": "string"
+            },
+            "prev": {
+                "target": "$.prev",
+                "type": "float"
+            },
+            "time": {
+                "target": "$.time",
+                "type": "string"
+            },
+            "unit": {
+                "target": "$.unit",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/filings.json
+++ b/finnhub/filings.json
@@ -1,0 +1,58 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/stock/filings",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "symbol": false,
+            "cik": false,
+            "accessNumber": false,
+            "form": false,
+            "from": false,
+            "to": false
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$[*]",
+        "schema": {
+            "accessNumber": {
+                "target": "$.accessNumber",
+                "type": "string"
+            },
+            "symbol": {
+                "target": "$.symbol",
+                "type": "string"
+            },
+            "cik": {
+                "target": "$.cik",
+                "type": "string"
+            },
+            "form": {
+                "target": "$.form",
+                "type": "string"
+            },
+            "filedDate": {
+                "target": "$.filedDate",
+                "type": "string"
+            },
+            "acceptedDate": {
+                "target": "$.acceptedDate",
+                "type": "string"
+            },
+            "reportUrl": {
+                "target": "$.reportUrl",
+                "type": "string"
+            },
+            "filingUrl": {
+                "target": "$.filingUrl",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/general_news.json
+++ b/finnhub/general_news.json
@@ -1,0 +1,58 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/news",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "category": true,
+            "minId": false
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$[*]",
+        "schema": {
+            "category": {
+                "target": "$.category",
+                "type": "string"
+            },
+            "datetime": {
+                "target": "$.datetime",
+                "type": "int"
+            },
+            "headline": {
+                "target": "$.headline",
+                "type": "string"
+            },
+            "id": {
+                "target": "$.id",
+                "type": "int"
+            },
+            "image": {
+                "target": "$.image",
+                "type": "string"
+            },
+            "related": {
+                "target": "$.related",
+                "type": "string"
+            },
+            "source": {
+                "target": "$.source",
+                "type": "string"
+            },
+            "summary": {
+                "target": "$.summary",
+                "type": "string"
+            },
+            "url": {
+                "target": "$.url",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/ipo_calender.json
+++ b/finnhub/ipo_calender.json
@@ -1,0 +1,59 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/calendar/ipo",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "from_": true,
+            "from": {
+                "required": false,
+                "removeIfEmpty": true,
+                "template": "{{from_}}"
+            },
+            "to": true
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$.ipoCalendar[*]",
+        "schema": {
+            "date": {
+                "target": "$.date",
+                "type": "string"
+            },
+            "exchange": {
+                "target": "$.exchange",
+                "type": "string"
+            },
+            "name": {
+                "target": "$.name",
+                "type": "string"
+            },
+            "numberOfShares": {
+                "target": "$.numberOfShares",
+                "type": "int"
+            },
+            "price": {
+                "target": "$.price",
+                "type": "string"
+            },
+            "status": {
+                "target": "$.status",
+                "type": "string"
+            },
+            "symbol": {
+                "target": "$.symbol",
+                "type": "string"
+            },
+            "totalSharesValue": {
+                "target": "$.totalSharesValue",
+                "type": "float"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/patterns.json
+++ b/finnhub/patterns.json
@@ -1,0 +1,122 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/scan/pattern",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "symbol": true,
+            "resolution": true
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$.points[*]",
+        "schema": {
+            "aprice": {
+                "target": "$.aprice",
+                "type": "float"
+            },
+            "atime": {
+                "target": "$.atime",
+                "type": "int"
+            },
+            "bprice": {
+                "target": "$.bprice",
+                "type": "float"
+            },
+            "btime": {
+                "target": "$.btime",
+                "type": "int"
+            },
+            "cprice": {
+                "target": "$.cprice",
+                "type": "float"
+            },
+            "ctime": {
+                "target": "$.ctime",
+                "type": "int"
+            },
+            "dprice": {
+                "target": "$.dprice",
+                "type": "float"
+            },
+            "dtime": {
+                "target": "$.dtime",
+                "type": "int"
+            },
+            "end_price": {
+                "target": "$.end_price",
+                "type": "float"
+            },
+            "end_time": {
+                "target": "$.end_time",
+                "type": "int"
+            },
+            "entry": {
+                "target": "$.entry",
+                "type": "float"
+            },
+            "eprice": {
+                "target": "$.eprice",
+                "type": "float"
+            },
+            "etime": {
+                "target": "$.etime",
+                "type": "int"
+            },
+            "mature": {
+                "target": "$.mature",
+                "type": "float"
+            },
+            "patternname": {
+                "target": "$.patternname",
+                "type": "string"
+            },
+            "patterntype": {
+                "target": "$.patterntype",
+                "type": "string"
+            },
+            "profit1": {
+                "target": "$.profit1",
+                "type": "float"
+            },
+            "profit2": {
+                "target": "$.profit2",
+                "type": "float"
+            },
+            "sortTime": {
+                "target": "$.sortTime",
+                "type": "int"
+            },
+            "start_price": {
+                "target": "$.start_price",
+                "type": "float"
+            },
+            "start_time": {
+                "target": "$.start_time",
+                "type": "int"
+            },
+            "status": {
+                "target": "$.status",
+                "type": "string"
+            },
+            "stoploss": {
+                "target": "$.stoploss",
+                "type": "float"
+            },
+            "symbol": {
+                "target": "$.symbol",
+                "type": "string"
+            },
+            "terminal": {
+                "target": "$.terminal",
+                "type": "float"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/recommendations.json
+++ b/finnhub/recommendations.json
@@ -1,0 +1,49 @@
+{
+    "version": 1,
+    "request": {
+        "url": "https://finnhub.io/api/v1/stock/recommendation",
+        "method": "GET",
+        "authorization": {
+            "type": "QueryParam",
+            "keyParam": "token"
+        },
+        "params": {
+            "symbol": true
+        }
+    },
+    "response": {
+        "ctype": "application/json",
+        "tablePath": "$[*]",
+        "schema": {
+            "buy": {
+                "target": "$.buy",
+                "type": "int"
+            },
+            "hold": {
+                "target": "$.hold",
+                "type": "int"
+            },
+            "period": {
+                "target": "$.period",
+                "type": "string"
+            },
+            "sell": {
+                "target": "$.sell",
+                "type": "int"
+            },
+            "strongBuy": {
+                "target": "$.strongBuy",
+                "type": "int"
+            },
+            "strongSell": {
+                "target": "$.strongSell",
+                "type": "int"
+            },
+            "symbol": {
+                "target": "$.symbol",
+                "type": "string"
+            }
+        },
+        "orient": "records"
+    }
+}

--- a/finnhub/tests/tests.py
+++ b/finnhub/tests/tests.py
@@ -1,0 +1,5 @@
+from dataprep.data_connector import Connector
+
+
+def test_sanity():
+    pass


### PR DESCRIPTION
Adding support to a Fintech Website called [Finnhub](https://finnhub.io/docs/api).

Includes API support with Data Connector to fetch the following free endpoints:

**Stock Fundamentals:**

[General News](https://finnhub.io/docs/api#general-news)
[Company News](https://finnhub.io/docs/api#company-news)

**Reported Financials:** 
[filings](https://finnhub.io/docs/api#filings)
[Initial Public Offering](https://finnhub.io/docs/api#ipo-calendar)

**Stock estimates:** 
[Recommendation trends](https://finnhub.io/docs/api#recommendation-trends)
[Earnings surprises](https://finnhub.io/docs/api#company-earnings)
[Earnings calender](https://finnhub.io/docs/api#earnings-calendar)  (Done - But requires keywords like from within query())

**Technical Analysis:**
[Pattern Recognition](https://finnhub.io/docs/api#pattern-recognition)

**Alternate Data:**
[Covid-19](https://finnhub.io/docs/api#covid-19)

**Economic Data:**
[Country metadata](https://finnhub.io/docs/api#country)
[Economic Calender ](https://finnhub.io/docs/api#economic-calendar)

Closes #224