### PR TITLE
feat(connector): Config file changes to support universal parameter _…

### DIFF
--- a/dblp/publication.json
+++ b/dblp/publication.json
@@ -4,7 +4,7 @@
         "url": "https://dblp.org/search/publ/api",
         "method": "GET",
         "params": {
-            "q": false,
+            "q": true,
             "h": false,
             "f": false,
             "author": {
@@ -13,6 +13,9 @@
                 "removeIfEmpty": true,
                 "toKey": "q"
             }
+        },
+        "search": {
+            "key": "q"
         },
         "pagination": {
             "type": "offset",

--- a/finnhub/tests/tests.py
+++ b/finnhub/tests/tests.py
@@ -1,4 +1,4 @@
-from dataprep.data_connector import Connector
+from dataprep.connector import Connector
 
 
 def test_sanity():

--- a/spotify/album.json
+++ b/spotify/album.json
@@ -13,6 +13,9 @@
             "limit": false,
             "offset": false
         },
+        "search": {
+            "key": "q"
+        },
         "pagination": {
             "type": "offset",
             "offsetKey": "offset",

--- a/spotify/artist.json
+++ b/spotify/artist.json
@@ -13,6 +13,9 @@
             "limit": false,
             "offset": false
         },
+        "search": {
+            "key": "q"
+        },
         "pagination": {
             "type": "offset",
             "offsetKey": "offset",

--- a/twitter/tweets.json
+++ b/twitter/tweets.json
@@ -13,6 +13,9 @@
             "count": false,
             "max_id": false
         },
+        "search": {
+            "key": "q"
+        },
         "pagination": {
             "type": "seek",
             "seekId": "id",

--- a/yelp/businesses.json
+++ b/yelp/businesses.json
@@ -13,6 +13,9 @@
             "longitude": false,
             "limit": false
         },
+        "search": {
+            "key": "term"
+        },
         "pagination": {
             "type": "offset",
             "offsetKey": "offset",

--- a/youtube/tests/tests.py
+++ b/youtube/tests/tests.py
@@ -1,4 +1,4 @@
-from dataprep.data_connector import Connector
+from dataprep.connector import Connector
 
 
 def test_sanity():

--- a/youtube/videos.json
+++ b/youtube/videos.json
@@ -14,6 +14,9 @@
             "maxResults": false,
             "pageToken": false
         },
+        "search": {
+            "key": "q"
+        },
         "pagination": {
             "type": "token",
             "tokenKey": "pageToken",


### PR DESCRIPTION
Config file changes related to [feat(data_connector): full text search _q to be a universal parameter #356](https://github.com/sfu-db/dataprep/pull/356/commits/9407cf565e347fe3574a9240602b48256220d1d5) of dataprep.

Ex: 
For Yelp, "term" is used as the search key and "q" for the rest of the websites so far. This would now be "_q" for all websites so the user doesn't have to worry about the difference in nomenclature.
`"search": {
        "search_key": "term"
}`